### PR TITLE
fix(gitlab): restore custom domain and https choice

### DIFF
--- a/internal/model/gitproviderclientoption.go
+++ b/internal/model/gitproviderclientoption.go
@@ -34,6 +34,16 @@ func (gpo GitProviderClientOption) String() string {
 		gpo.Provider, maskToken(gpo.Token), gpo.Domain)
 }
 
+func (gpo GitProviderClientOption) DomainWithScheme() string {
+	prefix := "https://"
+
+	if !strings.HasPrefix(gpo.Domain, prefix) {
+		return prefix + gpo.Domain
+	}
+
+	return gpo.Domain
+}
+
 // maskToken is a helper function that masks all but the last 4 characters of a token.
 // If the token is 4 characters or less, it masks all characters.
 func maskToken(token string) string {

--- a/internal/provider/gitlab/client.go
+++ b/internal/provider/gitlab/client.go
@@ -190,10 +190,7 @@ func NewGitLabClient(ctx context.Context, option model.GitProviderClientOption) 
 	logger := log.Logger(ctx)
 	logger.Trace().Msg("Entering NewGitLabClient:")
 
-	withHTTPSScheme := "https://"
-	gitlab.WithBaseURL(withHTTPSScheme + option.Domain)
-
-	client, err := gitlab.NewClient(option.Token)
+	client, err := gitlab.NewClient(option.Token, gitlab.WithBaseURL(option.DomainWithScheme()))
 	if err != nil {
 		return Client{}, fmt.Errorf("failed to create a new gitlab client: %w", err)
 	}

--- a/internal/provider/targetfacade.go
+++ b/internal/provider/targetfacade.go
@@ -152,7 +152,14 @@ func isArchiveOrDirectory(provider string) bool {
 
 // repositoryExists checks if a repository with the given name exists on the provider.
 func repositoryExists(ctx context.Context, config configuration.ProviderConfig, provider interfaces.GitProvider, repositoryName string) bool {
-	metainfos, _ := provider.Metainfos(ctx, config, false)
+	logger := log.Logger(ctx)
+	metainfos, err := provider.Metainfos(ctx, config, false)
+
+	if err != nil {
+		logger.Error().Msgf("failed to get repository meta information. Aborting run. err: %s", err.Error())
+		panic(2)
+	}
+
 	for _, metainfo := range metainfos {
 		if strings.EqualFold(repositoryName, metainfo.OriginalName) {
 			return true


### PR DESCRIPTION
# Description

Wip of cleaning up the residue issues after remove go-git-providers.
This one fixes custom domain and auto add https issues for gitlab.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).

