### PR TITLE
feat(client): add proxy support

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -6,9 +6,9 @@
 name: Commit Lint
 on: [workflow_call] # yamllint disable-line rule:truthy
 
-permissions: 
-    contents: read
-    
+permissions:
+  contents: read
+
 jobs:
   conform:
     name: Commit (conform) analysis

--- a/.github/workflows/dependencyreview.yml
+++ b/.github/workflows/dependencyreview.yml
@@ -5,8 +5,8 @@
 name: "Dependency Review"
 on: [workflow_call] # yamllint disable-line rule:truthy
 
-permissions: 
-    contents: read
+permissions:
+  contents: read
 
 jobs:
   dependency-review:

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -6,10 +6,8 @@
 name: Golang Lint
 on: [workflow_call] # yamllint disable-line rule:truthy
 
-
-permissions: 
-    contents: read
-    
+permissions:
+  contents: read
 
 jobs:
   golangci:

--- a/.github/workflows/licenselint.yml
+++ b/.github/workflows/licenselint.yml
@@ -7,9 +7,8 @@ name: REUSE Compliance
 
 on: [workflow_call] # yamllint disable-line rule:truthy
 
-permissions: 
-    contents: read
-
+permissions:
+  contents: read
 
 jobs:
   reuse:

--- a/.github/workflows/misclint.yml
+++ b/.github/workflows/misclint.yml
@@ -6,10 +6,10 @@ name: MegaLinter
 on:
   workflow_call: # yamllint disable-line rule:truthy
 
-permissions: 
-    contents: read
-    security-events: write
-    
+permissions:
+  contents: read
+  security-events: write
+
 env:
   MEGALINTER_CONFIG: /development/megalinter.yml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ name: Golang Test
 
 on: [workflow_call] # yamllint disable-line rule:truthy
 
-permissions: 
-    contents: read
+permissions:
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,33 +15,33 @@ on:
     branches:
       - main
 
-permissions: 
+permissions:
   contents: read
 
 jobs:
   commitlint:
-    permissions: 
+    permissions:
       contents: read
     uses: ./.github/workflows/commitlint.yml
   dependencyreviewlint:
-    permissions: 
+    permissions:
       contents: read
     uses: ./.github/workflows/dependencyreview.yml
   licenselint:
-    permissions: 
+    permissions:
       contents: read
     uses: ./.github/workflows/licenselint.yml
   golint:
-    permissions: 
+    permissions:
       contents: read
     uses: ./.github/workflows/golint.yml
   misclint:
-    permissions: 
+    permissions:
       contents: read
       security-events: write
     uses: ./.github/workflows/misclint.yml
   test:
-    permissions: 
+    permissions:
       contents: read
     if: ${{ !failure() }}
     needs: [licenselint, golint, misclint] #TO-DO enable commitlint, dependencyreview when public

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -332,6 +332,7 @@ func createProviderClient(ctx context.Context, providerConfig configuration.Prov
 		Token:    providerConfig.Token,
 		Domain:   providerConfig.Domain,
 		Scheme:   providerConfig.Scheme,
+		ProxyURL: providerConfig.GitInfo.ProxyURL,
 	}
 
 	client, err := provider.NewGitProviderClient(ctx, option)

--- a/internal/configuration/printer.go
+++ b/internal/configuration/printer.go
@@ -86,10 +86,12 @@ func printGitProtocol(writer io.Writer, config ProviderConfig) {
 	if len(config.GitInfo.Type) == 0 {
 		fmt.Fprintf(writer, "  Type: %s\n", model.HTTPS)
 		fmt.Fprintf(writer, "  IncludeForks: %t\n", config.GitInfo.IncludeForks)
+		fmt.Fprintf(writer, "  ProxyURL: %s\n", config.GitInfo.ProxyURL)
 	} else {
 		fmt.Fprintf(writer, "  Type: %s\n", config.GitInfo.Type)
 		fmt.Fprintf(writer, "  SSHPrivateKeyPath: %s\n", config.GitInfo.SSHPrivateKeyPath)
 		fmt.Fprintf(writer, "  IncludeForks: %t\n", config.GitInfo.IncludeForks)
+		fmt.Fprintf(writer, "  ProxyURL: %s\n", config.GitInfo.ProxyURL)
 
 		if len(config.GitInfo.SSHPrivateKeyPW) == 0 {
 			fmt.Fprintln(writer, "  SSHPrivateKeyPW not specified")

--- a/internal/configuration/validator.go
+++ b/internal/configuration/validator.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"itiquette/git-provider-sync/internal/model"
+	"net/url"
 	"os"
 	"slices"
 	"strings"
@@ -129,6 +130,10 @@ func validateStandardProvider(config ProviderConfig) error {
 		return err
 	}
 
+	if err := validateGitInfo(config); err != nil {
+		return err
+	}
+
 	if len(config.Token) == 0 {
 		return ErrNoTargetToken
 	}
@@ -163,6 +168,13 @@ func validateGitInfo(config ProviderConfig) error {
 		_, err := os.Stat(config.GitInfo.SSHPrivateKeyPath)
 		if err != nil {
 			return fmt.Errorf("gitinfo type was sshkey, but keyfile: %s could not be read. err: %w", config.GitInfo.SSHPrivateKeyPath, ErrInvalidSSHKeyPath)
+		}
+	}
+
+	if config.GitInfo.ProxyURL != "" {
+		_, err := url.Parse(config.GitInfo.ProxyURL)
+		if err != nil {
+			return fmt.Errorf("gitinfo proxyurl is set but an invalid url: %w", err)
 		}
 	}
 

--- a/internal/model/gitoption.go
+++ b/internal/model/gitoption.go
@@ -11,6 +11,7 @@ type GitInfo struct {
 	SSHPrivateKeyPath string `koanf:"sshprivatekeypath"`
 	SSHPrivateKeyPW   string `koanf:"sshprivatekeypw"`
 	IncludeForks      bool   `koanf:"includeforks"`
+	ProxyURL          string `koanf:"proxyurl"`
 	ProviderToken     string
 }
 

--- a/internal/model/gitproviderclientoption.go
+++ b/internal/model/gitproviderclientoption.go
@@ -25,6 +25,9 @@ type GitProviderClientOption struct {
 
 	// Scheme is the scheme of the git provider service (e.g., "https", "http". Default if empty is https).
 	Scheme string
+
+	// ProxyURL is the url to a proxy for the client
+	ProxyURL string
 }
 
 // String provides a string representation of GitProviderClientOption.


### PR DESCRIPTION
Adds proxy support to all clients, configurable under gitoption.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).

