### PR TITLE
fix: set default branch after push

### DIFF
--- a/internal/interfaces/gitprovider.go
+++ b/internal/interfaces/gitprovider.go
@@ -31,6 +31,8 @@ type GitProvider interface {
 	//   - Handling any provider-specific requirements or limitations.
 	Create(ctx context.Context, config config.ProviderConfig, option model.CreateOption) error
 
+	DefaultBranch(ctx context.Context, owner string, projectname string, branch string) error
+
 	// Metainfos retrieves metadata for repositories from the Git provider.
 	//
 	// Parameters:

--- a/internal/model/createoption.go
+++ b/internal/model/createoption.go
@@ -4,6 +4,8 @@
 
 package model
 
+import "fmt"
+
 // CreateOption represents options for creating a new repository.
 // It includes the repository name, visibility settings, description,
 // and the name of the default branch.
@@ -12,6 +14,14 @@ type CreateOption struct {
 	Visibility     string // The visibility setting (e.g., "public", "private")
 	Description    string // A description of the repository
 	DefaultBranch  string // The name of the default branch (e.g., "main", "master")
+}
+
+func (co CreateOption) String() string {
+	return fmt.Sprintf("CreateOption{RepositoryName: %q, Visibility: %q, Description: %q, DefaultBranch: %q}",
+		co.RepositoryName,
+		co.Visibility,
+		co.Description,
+		co.DefaultBranch)
 }
 
 // NewCreateOption creates a new CreateOption.

--- a/internal/provider/archive/client.go
+++ b/internal/provider/archive/client.go
@@ -21,6 +21,10 @@ func (Client) Name() string {
 	return config.ARCHIVE
 }
 
+func (Client) DefaultBranch(_ context.Context, _ string, _ string, _ string) error {
+	return nil
+}
+
 func (Client) IsValidRepositoryName(_ context.Context, _ string) bool {
 	return true
 }

--- a/internal/provider/directory/client.go
+++ b/internal/provider/directory/client.go
@@ -21,6 +21,10 @@ func (Client) Name() string {
 	return config.DIRECTORY
 }
 
+func (Client) DefaultBranch(_ context.Context, _ string, _ string, _ string) error {
+	return nil
+}
+
 func (Client) IsValidRepositoryName(_ context.Context, _ string) bool {
 	return true
 }

--- a/internal/provider/gitea/client.go
+++ b/internal/provider/gitea/client.go
@@ -61,6 +61,11 @@ func (c Client) Create(ctx context.Context, config config.ProviderConfig, option
 	return nil
 }
 
+func (c Client) DefaultBranch(_ context.Context, _ string, _ string, _ string) error {
+	//TO-DO
+	return nil
+}
+
 // Name returns the name of the provider, which is "GITEA".
 func (c Client) Name() string {
 	return config.GITEA

--- a/internal/provider/github/client.go
+++ b/internal/provider/github/client.go
@@ -63,7 +63,7 @@ func (ghc Client) Create(ctx context.Context, config config.ProviderConfig, opti
 		groupName = config.Group
 	}
 
-	rep := &github.Repository{Name: &option.RepositoryName, Private: &isPrivate, Description: &option.Description}
+	rep := &github.Repository{Name: &option.RepositoryName, Private: &isPrivate, DefaultBranch: &option.DefaultBranch, Description: &option.Description}
 	_, _, err = ghc.rawClient.Repositories.Create(ctx, groupName, rep)
 
 	if err != nil {
@@ -164,6 +164,21 @@ func (ghc *Client) processRepositories(ctx context.Context, config config.Provid
 // Returns true if the repository name is valid, false otherwise.
 func (ghc *Client) Validate(ctx context.Context, name string) bool {
 	return ghc.IsValidRepositoryName(ctx, name)
+}
+
+func (ghc Client) DefaultBranch(ctx context.Context, owner string, projectName string, branch string) error {
+	logger := log.Logger(ctx)
+	logger.Trace().Msg("Entering GitHub:DefaultBranch:")
+	logger.Debug().Str("branch", branch).Msg("GitHub:DefaultBranch:")
+
+	_, _, err := ghc.rawClient.Repositories.Edit(ctx, owner, projectName, &github.Repository{
+		DefaultBranch: github.String(branch),
+	})
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	return nil
 }
 
 // IsValidRepositoryName checks if the given repository name is valid for GitHub.

--- a/internal/provider/gitlab/client.go
+++ b/internal/provider/gitlab/client.go
@@ -37,12 +37,14 @@ type Client struct {
 func (glc Client) Create(ctx context.Context, config config.ProviderConfig, option model.CreateOption) error {
 	logger := log.Logger(ctx)
 	logger.Trace().Msg("Entering GitLab:Create:")
-	config.DebugLog(logger).Msg("GitLab:Create:")
+	logger.Debug().Msg("Entering GitLab:Create:")
+	config.DebugLog(logger).Str("CreateOption", option.String()).Msg("GitLab:Create:")
 
 	ops := &gitlab.CreateProjectOptions{
-		Name:        gitlab.Ptr(option.RepositoryName),
-		Description: gitlab.Ptr(option.Description),
-		Visibility:  gitlab.Ptr(toVisibility(option.Visibility)),
+		Name:          gitlab.Ptr(option.RepositoryName),
+		Description:   gitlab.Ptr(option.Description),
+		DefaultBranch: gitlab.Ptr(option.DefaultBranch),
+		Visibility:    gitlab.Ptr(toVisibility(option.Visibility)),
 	}
 
 	_, _, err := glc.rawClient.Projects.CreateProject(ops)
@@ -52,6 +54,21 @@ func (glc Client) Create(ctx context.Context, config config.ProviderConfig, opti
 	}
 
 	logger.Trace().Msg("Repository created successfully")
+
+	return nil
+}
+
+func (glc Client) DefaultBranch(ctx context.Context, owner string, projectName string, branch string) error {
+	logger := log.Logger(ctx)
+	logger.Trace().Msg("Entering GitLab:DefaultBranch:")
+	logger.Debug().Str("name", branch).Msg("GitLab:DefaultBranch:")
+
+	_, _, err := glc.rawClient.Projects.EditProject(owner+"/"+projectName, &gitlab.EditProjectOptions{
+		DefaultBranch: gitlab.Ptr(branch),
+	})
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
 
 	return nil
 }

--- a/internal/provider/targetfacade.go
+++ b/internal/provider/targetfacade.go
@@ -23,6 +23,7 @@ var (
 	ErrTargetRepositoryName = errors.New("failed target repository name validation")
 	ErrCreateRepository     = errors.New("failed to create repository")
 	ErrPushChanges          = errors.New("failed to push changes")
+	ErrDefaultBranch        = errors.New("failed to set default branch")
 )
 
 // Push handles the process of pushing changes to a Git provider.
@@ -51,6 +52,15 @@ func Push(ctx context.Context, targetProviderConfig config.ProviderConfig, provi
 
 	if err := writer.Push(ctx, repository, pushOption, sourceProviderConfig, targetProviderConfig.Git); err != nil {
 		return fmt.Errorf("%w: %w", ErrPushChanges, err)
+	}
+
+	owner := targetProviderConfig.Group
+	if len(targetProviderConfig.Group) == 0 {
+		owner = targetProviderConfig.User
+	}
+
+	if err := provider.DefaultBranch(ctx, owner, repository.Metainfo().Name(ctx), repository.Metainfo().DefaultBranch); err != nil {
+		return fmt.Errorf("%w: %w", ErrDefaultBranch, err)
 	}
 
 	return nil


### PR DESCRIPTION
After creating a repo, a call needs to be done to the provider to set the default branch (this cant be done on creation).
This adds prel support for that, leaving gitea until next iteration.

Fixes #57 

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).

