### PR TITLE
feat: add custom ssh command, git binary support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -89,6 +89,16 @@ Check out our https://github.com/itiquette/git-provider-sync/issues[Issues page]
 Git Provider Sync is slowly getting stable and reliable.
 But as with any tool, it's always good to be careful!
 
+== Documenting the project journey
+
+I'm writing a log of how this project is becoming useful. 
+Chapters are
+
+1. https://dev.to/janderssonse/from-friday-hack-to-release-reflections-on-creating-and-releasing-a-open-source-project-1ljg[From hack to release - reflections]
+2. Learning Go as a Java developer
+3. Open Source Practices 
+4. Open Source Security 
+
 == Legal Stuff
 
 Git Provider Sync is licensed under the EUPL 1.2 License.

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -6,9 +6,12 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	mocks "itiquette/git-provider-sync/generated/mocks/mockgogit"
+	"itiquette/git-provider-sync/internal/log"
 	"itiquette/git-provider-sync/internal/model"
 	config "itiquette/git-provider-sync/internal/model/configuration"
 
@@ -30,61 +33,61 @@ import (
 // 	_ = cmd.Execute()
 // }
 
-// func TestCreateTmpDir(t *testing.T) {
-// 	require := require.New(t)
+func TestCreateTmpDir(t *testing.T) {
+	require := require.New(t)
 
-// 	type args struct {
-// 		dir    string
-// 		prefix string
-// 	}
+	type args struct {
+		dir    string
+		prefix string
+	}
 
-// 	tests := map[string]struct {
-// 		args    args
-// 		want    string
-// 		wantErr bool
-// 	}{
-// 		"default os tmp dir with regular name success": {
-// 			args: args{dir: "", prefix: "gitprovidersync"},
-// 			want: filepath.Join(os.TempDir(), "gitprovidersync."),
-// 		},
-// 		"invalid os characters for tmp directory fail": {
-// 			args:    args{dir: "#¤%&/()=?!", prefix: "guthostsync"},
-// 			want:    "",
-// 			wantErr: true,
-// 		},
-// 		"non-existent directory fail": {
-// 			args:    args{dir: "/nonexistent", prefix: "test"},
-// 			want:    "",
-// 			wantErr: true,
-// 		},
-// 		// "custom directory success": {
-// 		// 	args: args{dir: "/tmp/custom", prefix: "gitprovidersync"},
-// 		// 	want: filepath.Join("/tmp/custom", "gitprovidersync."),
-// 		// },
-// 		"empty prefix success": {
-// 			args: args{dir: "", prefix: ""},
-// 			want: filepath.Join(os.TempDir(), ""),
-// 		},
-// 	}
+	tests := map[string]struct {
+		args    args
+		want    string
+		wantErr bool
+	}{
+		"default os tmp dir with regular name success": {
+			args: args{dir: "", prefix: "gitprovidersync"},
+			want: filepath.Join(os.TempDir(), "gitprovidersync."),
+		},
+		"invalid os characters for tmp directory fail": {
+			args:    args{dir: "#¤%&/()=?!", prefix: "guthostsync"},
+			want:    "",
+			wantErr: true,
+		},
+		"non-existent directory fail": {
+			args:    args{dir: "/nonexistent", prefix: "test"},
+			want:    "",
+			wantErr: true,
+		},
+		// "custom directory success": {
+		// 	args: args{dir: "/tmp/custom", prefix: "gitprovidersync"},
+		// 	want: filepath.Join("/tmp/custom", "gitprovidersync."),
+		// },
+		"empty prefix success": {
+			args: args{dir: "", prefix: ""},
+			want: filepath.Join(os.TempDir(), ""),
+		},
+	}
 
-// 	for name, tableTest := range tests {
-// 		ctx := context.Background()
-// 		ctx = log.InitLogger(ctx, newPrintCommand(), false, string(log.CONSOLE))
+	for name, tableTest := range tests {
+		ctx := context.Background()
+		ctx = log.InitLogger(ctx, newPrintCommand(), false, string(log.CONSOLE))
 
-// 		t.Run(name, func(_ *testing.T) {
-// 			ctx, err := model.CreateTmpDir(ctx, tableTest.args.dir, tableTest.args.prefix)
+		t.Run(name, func(_ *testing.T) {
+			ctx, err := model.CreateTmpDir(ctx, tableTest.args.dir, tableTest.args.prefix)
 
-// 			if !tableTest.wantErr {
-// 				tmpDir, _ := ctx.Value(model.TmpDirKey{}).(string)
-// 				require.DirExists(tmpDir, "tmp directory should exist")
-// 				require.Contains(tmpDir, tableTest.want, "tmp directory name should contain prefix")
-// 			} else {
-// 				require.Error(err, "error should be returned")
-// 				require.Contains(err.Error(), "failed to create temporary", "error message should be descriptive")
-// 			}
-// 		})
-// 	}
-// }
+			if !tableTest.wantErr {
+				tmpDir, _ := ctx.Value(model.TmpDirKey{}).(string)
+				require.DirExists(tmpDir, "tmp directory should exist")
+				require.Contains(tmpDir, tableTest.want, "tmp directory name should contain prefix")
+			} else {
+				require.Error(err, "error should be returned")
+				require.Contains(err.Error(), "failed to create temporary", "error message should be descriptive")
+			}
+		})
+	}
+}
 
 func TestNewSyncCommand(t *testing.T) {
 	cmd := newSyncCommand()

--- a/docs/usage.adoc
+++ b/docs/usage.adoc
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
 = Git Provider Sync: Usage Guide
-:toc: preamble
+:toc: 
 :toc-title: 
 :revdate: {docdatetime}
 :doctype: article
@@ -33,11 +33,12 @@ Git Provider Sync allows you to:
 
 1. Install Git Provider Sync
    * Use a pre-offered package OR build it yourself
-   * See the link:../INSTALL.adoc[installation guide] for options
+   * See the link:../INSTALL.adoc[installation guide] for installation options
 
-2. Create a configuration file
+2. Create a basic configuration file
    * Set up at least one source provider and target provider
-   * See link:../examples/gitprovidersync.exampleconf.yaml[example configuration]
+   * See link:../examples/gitprovidersync.exampleconf.yaml[example configuration] for all possible settings.
+   * See <<_cli_usage_examples>> and <<_configuration_examples>> for a few examples
 
 3. Verify your configuration
 +
@@ -62,7 +63,7 @@ gitprovidersync sync
 gitprovidersync --help
 ----
 
-* Read the man page (only if installed as package - deb, rpm, apk):
+* Read the man page (if installed as package - deb, rpm, apk):
 +
 [source,console]
 ----
@@ -71,7 +72,7 @@ man gitprovidersync
 
 NOTE: The `--from` option should be in https://pkg.go.dev/time#ParseDuration[Go duration string form].
 
-== Usage Examples
+== CLI Usage Examples
 
 === Print Current Configuration
 
@@ -103,6 +104,8 @@ gitprovidersync --force-push --from='-3h' --cleanup-name --config-file /usr/bin/
 
 === Configuration Methods
 
+TIP: For configuration examples, see link:../examples/gitprovidersync.exampleconf.yaml[the example configuration file].
+
 Configuration can be provided through:
 
 1. Environment variables
@@ -114,19 +117,92 @@ Priority order: 1 > 2 > 3 > 4
 
 === Configuration Notes
 
-* Environment variables:
+==== Environment variables:
   ** Must start with `GPS_`
   ** Use uppercase with underscore separation
   ** Example: `GPS_CONFIGURATIONS_SOURCE_PROVIDER=envconfprovider`
 
-* .env file:
+==== .env file:
   ** Use uppercase with underscore separation
   ** Example: `CONFIGURATIONS_SOURCE_PROVIDER=dotenvprovider`
 
-TIP: For configuration examples, see link:../examples/gitprovidersync.exampleconf.yaml[the example configuration file].
+==== Advanced Configuration
+
+===== Using a host Git Binary instead of the underlying Go Git Library
+
+In certain cases you might like to use the underlying host Git Binary instead of the built in Go Git-library.
+For example, If you would like to customize the underlying SSH-client with GIT_SSH_COMMAND. 
+Go Git does not currently support SSH-client customisation.
+
+NOTE: Only use this if you really have to (for example, you might want to use the SSH ProxyCommand option).
+
+=== Configuration Examples
+
+.A sync from github to gitlab, archive dir, and a dir. Because we can. NOTE DONT PUT SECRETS IN CONFIG FILES OTHER THAN FOR TESTING, use envs or alike
+[source,yaml]
+----
+configurations: 
+  itiquettesource: 
+    source: 
+      providertype: github
+      domain: github.com
+      group: itiquette 
+      httpclient:
+        token: <a-github-token-so-we-avoid-rate-limiting-etc>
+      repositories:
+        include: org-feature-test-repo # we only want one repo from this org
+
+    targets:
+      agitlabtarget:
+        providertype: gitlab
+        domain: gitlab.com 
+        user: <a-gitlab-user>
+        httpclient:
+          token: <a-gitlab-token-with-create-and-write-access>
+     
+     tartargetexample: 
+       providertype: archive 
+       additional: 
+         archivetargetdir: /tmp/myarcdir
+     
+     directoryexample: 
+       providertype: directory
+       additional: 
+         directorytargetdir: /tmp/mydir
+
+----
+
+.A sync from gitlab to github. special case, uses gitbinary, sshagent and custom ssh-client to push ssh through githubs https endpoint. It also uses corkscrew on the host.
+[source,yaml]
+----
+configurations: 
+  itiquettesource: 
+    source: 
+      providertype: gitlab
+      domain: gitlab.com
+      group: hanklank
+      httpclient:
+        token: <a-gitlab-token>
+      repositories:
+        include: org-feature-test-repo # we only want one repo from this org
+
+    targets:
+      agithubtarget:
+        providertype: github
+        domain: github.com 
+        user: <a-gitlab-user>
+        httpclient:
+          token: <a-gitlab-token-with-create-and-write-access>
+        sshclient:
+          proxycommand: ssh -vvv -o ProxyCommand="corkscrew <proxyserver> <proxyserverport> %h %p" -o ConnectTimeout=10 -p 443  #This SSH command uses corkscrew to tunnel SSH through an HTTP proxy. It's set to maximum verbosity (-vvv), uses a 10-second connection timeout, and connects to the SSH server on port 443. The ProxyCommand option specifies the proxy server and port, with %h and %p as placeholders for the SSH server host and port
+          rewritesshurlfrom: git@github.com:
+          rewritesshurlto: ssh://git@ssh.github.com:443/
+        git:
+          type: sshagent
+          usegitbinary: true
+----
 
 == Provider-Specific Notes
-
 
 === Visibility Mappings
 
@@ -162,7 +238,7 @@ Listed is how they will be synced.
 === Authentication
 
 * Default: Basic Auth (requires token in configuration)
-* Alternative: SSH (configure `gitinfo.type` as https, sshagen, or sshkey)
+* Alternative: SSH (configure `gitinfo.type` as sshagent)
 
 === GitHub
 
@@ -702,3 +778,12 @@ spec:
       value: "token"
     - name: ACTIVE_FROM_LIMIT
       value: "-30000h"
+
+----
+
+== F.A.Q 
+
+* Do I need to use both https and ssh in the same configuration?
+
+  No. 
+  To keep it simple, just use https and tokens. However, if you need it, ssh support is there. Speaking with various Git Providers Https API's is one thing - listing projects and so on, and pure Git operations another - clone, push and so on. So if you are using ssh for the git operations, you will still need to configure https options also (for metadata)

--- a/examples/gitprovidersync.exampleconf.yaml
+++ b/examples/gitprovidersync.exampleconf.yaml
@@ -11,10 +11,8 @@ configurations: # a list of project configurations. Mandatory - at least one.
       group: group # Git provider group/organization owner. Mandatory (if no user given).  Mutually exclusive with user
       httpclient:
         token: git provider token. Optional but recommended to avoid GitHub-api limits, private repositories etc.
-      git: # https,sshagent,sshkey (default if empty is https)
-        type: sshkey
-        sshprivatekeypath: /key/path # Only applicable if sshkey was sethhhhhhhhh
-        sshprivatekeypw: #dont use saved pws here other htan for test
+      git: # https,sshagent (default if empty is https)
+        type: sshagent
       repositories:
         include: a-dummy-project, another-dummy-project # Git provider repositories to include. Optional (if empty, all are mirrored))
         exclude: a-dummy-project, another-dummy-project # Git provider repositories to exclude. Optional (if empty, none are excluded)

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
-	golang.org/x/crypto v0.28.0 // indirect
+	golang.org/x/crypto v0.28.0
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect

--- a/internal/configuration/printer.go
+++ b/internal/configuration/printer.go
@@ -80,8 +80,11 @@ func printRemoteProviderDetails(config config.ProviderConfig, writer io.Writer) 
 	// Protocol
 	printGitProtocol(writer, config)
 
-	fmt.Fprintf(writer, " Include: %s", config.Repositories.Include)
-	fmt.Fprintf(writer, " Exclude: %s", config.Repositories.Exclude)
+	// SSHClientOptions
+	printSSHClientOption(writer, config)
+
+	fmt.Fprintf(writer, " Include: %s\n", config.Repositories.Include)
+	fmt.Fprintf(writer, " Exclude: %s\n", config.Repositories.Exclude)
 }
 
 func printGitProtocol(writer io.Writer, providerConfig config.ProviderConfig) {
@@ -89,17 +92,21 @@ func printGitProtocol(writer io.Writer, providerConfig config.ProviderConfig) {
 
 	if len(providerConfig.Git.Type) == 0 {
 		fmt.Fprintf(writer, "  Type: %s\n", config.HTTPS)
+		fmt.Fprintf(writer, "  UseGitBinary: %t\n", providerConfig.Git.UseGitBinary)
 		fmt.Fprintf(writer, "  IncludeForks: %t\n", providerConfig.Git.IncludeForks)
 	} else {
 		fmt.Fprintf(writer, "  Type: %s\n", providerConfig.Git.Type)
-		fmt.Fprintf(writer, "  SSHPrivateKeyPath: %s\n", providerConfig.Git.SSHPrivateKeyPath)
+		fmt.Fprintf(writer, "  UseGitBinary: %t\n", providerConfig.Git.UseGitBinary)
 		fmt.Fprintf(writer, "  IncludeForks: %t\n", providerConfig.Git.IncludeForks)
+	}
+}
 
-		if len(providerConfig.Git.SSHPrivateKeyPW) == 0 {
-			fmt.Fprintln(writer, "  SSHPrivateKeyPW not specified")
-		} else {
-			fmt.Fprintln(writer, "  SSHPrivateKeyPW: <*****>")
-		}
+func printSSHClientOption(writer io.Writer, providerConfig config.ProviderConfig) {
+	if len(providerConfig.SSHClient.ProxyCommand) >= 0 {
+		fmt.Fprint(writer, " SSHClientOptions:\n")
+		fmt.Fprintf(writer, "  ProxyCommand: %s\n", providerConfig.SSHClient.ProxyCommand)
+		fmt.Fprintf(writer, "  RewriteSSHURLFrom: %s\n", providerConfig.SSHClient.RewriteSSHURLFrom)
+		fmt.Fprintf(writer, "  RewriteSSHURLTo: %s\n", providerConfig.SSHClient.RewriteSSHURLTo)
 	}
 }
 

--- a/internal/interfaces/git.go
+++ b/internal/interfaces/git.go
@@ -4,11 +4,6 @@
 
 package interfaces
 
-import (
-	"context"
-	"itiquette/git-provider-sync/internal/model"
-)
-
 // GitInterface defines a comprehensive interface for Git operations.
 // It combines the capabilities of SourceReader and TargetWriter,
 // along with additional methods for pulling and fetching.
@@ -35,7 +30,7 @@ type GitInterface interface {
 	//   - Merging or rebasing the pulled changes as specified in the options.
 	//   - Handling merge conflicts if they occur.
 	//   - Updating the local repository state after the pull.
-	Pull(ctx context.Context, option model.PullOption) error
+	//	Pull(ctx context.Context, option model.PullOption) error
 
 	// Fetch retrieves updates from a remote repository without merging them.
 	//
@@ -51,7 +46,7 @@ type GitInterface interface {
 	//   - Retrieving updates for all tracked branches.
 	//   - Updating remote-tracking branches in the local repository.
 	//   - Not modifying the working directory or current branch.
-	Fetch(ctx context.Context, repository model.Repository) error
+	//Fetch(ctx context.Context, workingDir string) error
 }
 
 // Note: The SourceReader and TargetWriter interfaces should be defined

--- a/internal/model/cloneoption.go
+++ b/internal/model/cloneoption.go
@@ -21,7 +21,9 @@ type CloneOption struct {
 	Mirror      bool   // Whether to create a mirror clone
 	Git         model.GitOption
 	HTTPClient  model.HTTPClientOption
+	SSHClient   model.SSHClientOption
 	PlainRepo   bool
+	Name        string
 }
 
 // NewCloneOption creates a new CloneOption.
@@ -37,7 +39,7 @@ func NewCloneOption(ctx context.Context, metainfo RepositoryMetainfo, mirror boo
 	logger := log.Logger(ctx)
 
 	var cloneURL string
-	if strings.EqualFold(providerConfig.Git.Type, model.SSHAGENT) || strings.EqualFold(providerConfig.Git.Type, model.SSHKEY) {
+	if strings.EqualFold(providerConfig.Git.Type, model.SSHAGENT) {
 		cloneURL = metainfo.SSHURL
 	} else {
 		cloneURL = metainfo.HTTPSURL
@@ -47,7 +49,7 @@ func NewCloneOption(ctx context.Context, metainfo RepositoryMetainfo, mirror boo
 		Str("url", cloneURL).
 		Msg("Cloning repository")
 
-	return CloneOption{URL: cloneURL, Mirror: mirror, Git: providerConfig.Git, HTTPClient: providerConfig.HTTPClient}
+	return CloneOption{URL: cloneURL, Mirror: mirror, Git: providerConfig.Git, HTTPClient: providerConfig.HTTPClient, SSHClient: providerConfig.SSHClient, Name: metainfo.Name(ctx)}
 }
 
 // String provides a string representation of CloneOption.

--- a/internal/model/configuration/gitoption.go
+++ b/internal/model/configuration/gitoption.go
@@ -6,21 +6,30 @@ package model
 
 import "fmt"
 
+// GitOption represents configuration options for Git operations.
 type GitOption struct {
-	Type              string `koanf:"type"`
-	SSHPrivateKeyPath string `koanf:"sshprivatekeypath"`
-	SSHPrivateKeyPW   string `koanf:"sshprivatekeypw"`
-	IncludeForks      bool   `koanf:"includeforks"`
+	Type         string `koanf:"type"`
+	IncludeForks bool   `koanf:"includeforks"`
+	UseGitBinary bool   `koanf:"usegitbinary"`
 }
 
+// String returns a string representation of GitOption, masking sensitive information.
 func (p GitOption) String() string {
-	return fmt.Sprintf("GitOption: Type: %s, SSHPrivateKeyPath: %s, SSHPrivateKeyPW: %s",
-		p.Type, p.SSHPrivateKeyPath, "****")
+	return fmt.Sprintf("GitOption: Type: %s, IncludeForks: %v, UseGitBinary: %v",
+		p.Type, p.IncludeForks, p.UseGitBinary)
+}
+
+// NewGitOption creates a new GitOption with default values.
+func NewGitOption() *GitOption {
+	return &GitOption{
+		Type:         "https",
+		IncludeForks: false,
+		UseGitBinary: false,
+	}
 }
 
 const (
 	SSHAGENT string = "sshagent"
 	HTTPS    string = "https"
 	HTTP     string = "http"
-	SSHKEY   string = "sshkey"
 )

--- a/internal/model/configuration/providerconfig.go
+++ b/internal/model/configuration/providerconfig.go
@@ -20,6 +20,7 @@ type ProviderConfig struct {
 	Repositories RepositoriesOption `koanf:"repositories"`
 	Git          GitOption          `koanf:"git"`
 	HTTPClient   HTTPClientOption   `koanf:"httpclient"`
+	SSHClient    SSHClientOption    `koanf:"sshclient"`
 	Scheme       string             `koanf:"scheme"`
 	Additional   map[string]string  `koanf:"additional"`
 }

--- a/internal/model/configuration/providerconfig_test.go
+++ b/internal/model/configuration/providerconfig_test.go
@@ -30,7 +30,7 @@ func TestProviderConfig_String(t *testing.T) {
 				Repositories: RepositoriesOption{Exclude: "excluded", Include: "included"},
 				Additional:   map[string]string{"key": "value"},
 			},
-			expected: "ProviderConfig: ProviderType: github, Domain: github.com, User: user1, Group: group1, Repository: RepositoryOption: Exclude excluded, Include: included, Git: GitOption: Type: , SSHPrivateKeyPath: , SSHPrivateKeyPW: ****,   HTTPClient: HTTPClientOption: ProxyURL , Token: **cret, Scheme: https, Extras: map[key:value]",
+			expected: "ProviderConfig: ProviderType: github, Domain: github.com, User: user1, Group: group1, Repository: RepositoryOption: Exclude excluded, Include: included, Git: GitOption: Type: , IncludeForks: false, UseGitBinary: false,   HTTPClient: HTTPClientOption: ProxyURL , Token: **cret, Scheme: https, Extras: map[key:value]",
 		},
 		{
 			name: "Minimal config",
@@ -38,7 +38,7 @@ func TestProviderConfig_String(t *testing.T) {
 				ProviderType: "gitlab",
 				Domain:       "gitlab.com",
 			},
-			expected: "ProviderConfig: ProviderType: gitlab, Domain: gitlab.com, User: , Group: , Repository: RepositoryOption: Exclude , Include: , Git: GitOption: Type: , SSHPrivateKeyPath: , SSHPrivateKeyPW: ****,   HTTPClient: HTTPClientOption: ProxyURL , Token: , Scheme: , Extras: map[]",
+			expected: "ProviderConfig: ProviderType: gitlab, Domain: gitlab.com, User: , Group: , Repository: RepositoryOption: Exclude , Include: , Git: GitOption: Type: , IncludeForks: false, UseGitBinary: false,   HTTPClient: HTTPClientOption: ProxyURL , Token: , Scheme: , Extras: map[]",
 		},
 		{
 			name: "Config with empty token",
@@ -47,7 +47,7 @@ func TestProviderConfig_String(t *testing.T) {
 				Domain:       "bitbucket.org",
 				HTTPClient:   HTTPClientOption{Token: ""},
 			},
-			expected: "ProviderConfig: ProviderType: bitbucket, Domain: bitbucket.org, User: , Group: , Repository: RepositoryOption: Exclude , Include: , Git: GitOption: Type: , SSHPrivateKeyPath: , SSHPrivateKeyPW: ****,   HTTPClient: HTTPClientOption: ProxyURL , Token: , Scheme: , Extras: map[]",
+			expected: "ProviderConfig: ProviderType: bitbucket, Domain: bitbucket.org, User: , Group: , Repository: RepositoryOption: Exclude , Include: , Git: GitOption: Type: , IncludeForks: false, UseGitBinary: false,   HTTPClient: HTTPClientOption: ProxyURL , Token: , Scheme: , Extras: map[]",
 		},
 	}
 

--- a/internal/model/configuration/sshclientoption.go
+++ b/internal/model/configuration/sshclientoption.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024 Josef Andersson
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package model
+
+import "strings"
+
+type SSHClientOption struct {
+	ProxyCommand      string `koanf:"proxycommand"`
+	RewriteSSHURLFrom string `koanf:"rewritesshurlfrom"`
+	RewriteSSHURLTo   string `koanf:"rewritesshurlto"`
+}
+
+func (p SSHClientOption) String() string {
+	var parts []string
+
+	parts = append(parts, "SSHClientOption{")
+
+	if p.ProxyCommand != "" {
+		parts = append(parts, "ProxyCommand: "+p.ProxyCommand)
+	}
+
+	if p.RewriteSSHURLFrom != "" {
+		parts = append(parts, "RewriteSSHURLFrom: "+p.RewriteSSHURLFrom)
+	}
+
+	if p.RewriteSSHURLTo != "" {
+		parts = append(parts, "RewriteSSHURLTo: "+p.RewriteSSHURLTo)
+	}
+
+	parts = append(parts, "}")
+
+	return strings.Join(parts, " ")
+}

--- a/internal/model/pulloption.go
+++ b/internal/model/pulloption.go
@@ -18,6 +18,7 @@ type PullOption struct {
 	URL              string                 // The URL of the remote repository
 	GitOption        model.GitOption        // GitOption options
 	HTTPClientOption model.HTTPClientOption // GitOption options
+	SSHClient        model.SSHClientOption  // GitOption options
 }
 
 // DebugLog creates a debug log event with repository metadata.
@@ -26,7 +27,6 @@ func (po PullOption) DebugLog(logger *zerolog.Logger) *zerolog.Event {
 	return logger.Debug(). //nolint:zerologlint
 				Str("target", po.Name).
 				Str("gitoption.type", po.GitOption.Type).
-				Str("gitoption.sshprivatekeypath", po.GitOption.SSHPrivateKeyPath).
 				Bool("gitoption.includeforks", po.GitOption.IncludeForks).
 				Str("prune", po.URL)
 }

--- a/internal/model/pushoption.go
+++ b/internal/model/pushoption.go
@@ -21,6 +21,7 @@ type PushOption struct {
 	Prune      bool     // Whether to prune remote branches that no longer exist locally
 	Force      bool     // Whether to force push (overwrite remote history)
 	HTTPClient model.HTTPClientOption
+	SSHClient  model.SSHClientOption
 }
 
 // String provides a string representation of PushOption.

--- a/internal/model/tmpDir.go
+++ b/internal/model/tmpDir.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2024 Josef Andersson
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package model
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"itiquette/git-provider-sync/internal/log"
+)
+
+// TmpDirKey is the key type for storing and retrieving the temporary directory path in the context.
+// Using a custom type for the key helps prevent collisions with other context values.
+type TmpDirKey struct{}
+
+// GetTmpDirPath retrieves the temporary directory path from the context.
+// It ensures that the path exists and is not empty before returning.
+//
+// Parameters:
+//   - ctx: The context containing the temporary directory path.
+//
+// Returns:
+//   - string: The path to the temporary directory.
+//   - error: An error if the path is not found or is empty.
+//
+// Usage:
+//
+//	path, err := GetTmpDirPath(ctx)
+//	if err != nil {
+//	    log.Printf("Failed to get temp dir: %v", err)
+//	    return
+//	}
+//	// Use the temporary directory path
+func GetTmpDirPath(ctx context.Context) (string, error) {
+	logger := log.Logger(ctx)
+	logger.Trace().Msg("Entering GetTmpDirPath: retrieving path")
+
+	tmpDir, ok := ctx.Value(TmpDirKey{}).(string)
+	if !ok || tmpDir == "" {
+		return "", errors.New("temporary directory path not found in context or is empty")
+	}
+
+	return tmpDir, nil
+}
+
+// CreateTmpDir creates a new temporary directory and stores its path in the context.
+// The directory is created using os.MkdirTemp, ensuring a unique name.
+//
+// Parameters:
+//   - ctx: The parent context.
+//   - dir: The parent directory in which to create the temporary directory. If empty, os.TempDir() is used.
+//   - prefix: The prefix for the temporary directory name.
+//
+// Returns:
+//   - context.Context: A new context containing the temporary directory path.
+//   - error: An error if the directory creation fails.
+//
+// Usage:
+//
+//	newCtx, err := CreateTmpDir(ctx, "", "myapp")
+//	if err != nil {
+//	    log.Printf("Failed to create temp dir: %v", err)
+//	    return
+//	}
+//	// Use newCtx in subsequent operations
+func CreateTmpDir(ctx context.Context, dir, prefix string) (context.Context, error) {
+	tmpDir, err := os.MkdirTemp(dir, prefix+".*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary directory (dir: %s, prefix: %s): %w", dir, prefix, err)
+	}
+
+	return context.WithValue(ctx, TmpDirKey{}, tmpDir), nil
+}
+
+// DeleteTmpDir safely deletes the temporary directory specified in the context.
+// It performs several safety checks to ensure the directory is valid before deletion.
+//
+// Parameters:
+//   - ctx: The context containing the temporary directory path.
+//
+// Returns:
+//   - error: An error if the deletion fails or if the directory is invalid.
+//
+// Usage:
+//
+//	if err := DeleteTmpDir(ctx); err != nil {
+//	    log.Printf("Failed to delete temp dir: %v", err)
+//	    return
+//	}
+func DeleteTmpDir(ctx context.Context) error {
+	logger := log.Logger(ctx)
+
+	tmpDir, err := GetTmpDirPath(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get temporary directory path: %w", err)
+	}
+
+	if !filepath.IsAbs(tmpDir) || !isSubdirectoryOfTemp(tmpDir) {
+		return fmt.Errorf("invalid temporary directory path: %s", tmpDir)
+	}
+
+	logger.Debug().Str("tmpDir", tmpDir).Msg("Deleting temporary directory")
+
+	if err := os.RemoveAll(tmpDir); err != nil {
+		return fmt.Errorf("failed to delete temporary directory %s: %w", tmpDir, err)
+	}
+
+	return nil
+}
+
+// isSubdirectoryOfTemp checks if the given path is a subdirectory of the system's temporary directory.
+// This is a safety measure to prevent accidental deletion of non-temporary directories.
+//
+// Parameters:
+//   - path: The path to check.
+//
+// Returns:
+//   - bool: True if the path is a subdirectory of the system's temporary directory, false otherwise.
+func isSubdirectoryOfTemp(path string) bool {
+	tempDir := os.TempDir()
+
+	return strings.HasPrefix(path, tempDir)
+}

--- a/internal/provider/sourcefacade_test.go
+++ b/internal/provider/sourcefacade_test.go
@@ -34,7 +34,7 @@ func TestClone(t *testing.T) {
 				{HTTPSURL: "https://github.com/user/repo2.git", OriginalName: "repo2"},
 			},
 			mockSetup: func(m *mocks.SourceReader) {
-				m.On("Clone", mock.Anything, mock.Anything).Return(model.Repository{}, nil).Twice()
+				m.EXPECT().Clone(mock.Anything, mock.Anything).Return(model.Repository{}, nil).Twice()
 			},
 			wantErr: false,
 		},
@@ -44,7 +44,7 @@ func TestClone(t *testing.T) {
 				{HTTPSURL: "https://github.com/user/repo1.git", OriginalName: "repo1"},
 			},
 			mockSetup: func(m *mocks.SourceReader) {
-				m.On("Clone", mock.Anything, mock.Anything).Return(model.Repository{}, errors.New("clone failed"))
+				m.EXPECT().Clone(mock.Anything, mock.Anything).Return(model.Repository{}, errors.New("clone failed"))
 			},
 			wantErr: true,
 		},

--- a/internal/target/archive.go
+++ b/internal/target/archive.go
@@ -32,7 +32,7 @@ var (
 
 // Archive represents a structure capable of pushing Git repositories to archive files.
 type Archive struct {
-	gitClient Git
+	gitClient GitLib
 }
 
 // Push initializes a target repository and creates an archive of it.
@@ -123,8 +123,8 @@ func mapFilesToArchive(sourceDir, targetName string) ([]archiver.File, error) {
 }
 
 // NewArchive creates a new Archive instance.
-func NewArchive(ctx context.Context, repo interfaces.GitRepository) *Archive {
-	return &Archive{gitClient: NewGit(repo, repo.Metainfo().Name(ctx))}
+func NewArchive() *Archive {
+	return &Archive{gitClient: NewGitLib()}
 }
 
 func getSourceDirPath(opt model.PushOption) (string, error) {

--- a/internal/target/directory.go
+++ b/internal/target/directory.go
@@ -28,7 +28,7 @@ var (
 
 // Directory represents a target directory for git operations.
 type Directory struct {
-	gitClient Git
+	gitClient GitLib
 }
 
 // Push performs a push operation on the target directory.
@@ -37,7 +37,7 @@ func (dir Directory) Push(ctx context.Context, repo interfaces.GitRepository, op
 	logger.Trace().Msg("Entering Directory:Push")
 	opt.DebugLog(logger).Msg("Directory:Push")
 
-	targetDir, err := getTargetDirPath(ctx, opt.Target, dir.gitClient.name)
+	targetDir, err := getTargetDirPath(ctx, opt.Target, repo.Metainfo().Name(ctx))
 	if err != nil {
 		return fmt.Errorf("%w %w", ErrDirGetPath, err)
 	}
@@ -100,6 +100,6 @@ func directoryExists(dir string) bool {
 }
 
 // NewDirectory creates a new Directory Target instance.
-func NewDirectory(ctx context.Context, repo interfaces.GitRepository) Directory {
-	return Directory{gitClient: NewGit(repo, repo.Metainfo().Name(ctx))}
+func NewDirectory() Directory {
+	return Directory{gitClient: NewGitLib()}
 }

--- a/internal/target/gitbinary.go
+++ b/internal/target/gitbinary.go
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2024 Josef Andersson
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+// Package target provides Git operations for repository management.
+package target
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"itiquette/git-provider-sync/internal/interfaces"
+	"itiquette/git-provider-sync/internal/log"
+	"itiquette/git-provider-sync/internal/model"
+	gpsconfig "itiquette/git-provider-sync/internal/model/configuration"
+
+	"github.com/go-git/go-git/v5"
+)
+
+type GitBinary struct {
+	gitBinaryPath string
+}
+
+func NewGitBinary() (GitBinary, error) {
+	binaryPath, err := ValidateGitBinary()
+	if err != nil {
+		return GitBinary{}, fmt.Errorf("failed to find Git Binary: %w", err)
+	}
+
+	if len(binaryPath) == 0 {
+		return GitBinary{}, errors.New("binaryPath to Git Binary was 0")
+	}
+
+	return GitBinary{
+		gitBinaryPath: binaryPath,
+	}, nil
+}
+
+func (g GitBinary) Clone(ctx context.Context, option model.CloneOption) (model.Repository, error) {
+	logger := log.Logger(ctx)
+	logger.Debug().Str("url", option.URL).Msg("Git:Clone")
+
+	fmt.Println(option.SSHClient.ProxyCommand)
+	env := setupSSHCommandEnv(option.SSHClient.ProxyCommand, option.SSHClient.RewriteSSHURLFrom, option.SSHClient.RewriteSSHURLTo)
+
+	fmt.Println(env)
+
+	tmpDirPath, err := model.GetTmpDirPath(ctx)
+	if err != nil {
+		return model.Repository{}, fmt.Errorf("failed to get tmpdirpath: %w", err)
+	}
+
+	destinationDir := filepath.Join(tmpDirPath, option.Name)
+
+	// Use the parent directory as the working directory
+	parentDir := filepath.Dir(destinationDir)
+
+	url := option.URL
+	if !strings.EqualFold(option.Git.Type, gpsconfig.SSHAGENT) {
+		url = addBasicAuthToURL(option.URL, "anyuser", option.HTTPClient.Token)
+	}
+
+	if err := g.runGitCommand(ctx, env, parentDir, "clone", url, destinationDir); err != nil {
+		if strings.Contains(err.Error(), "Permission denied (publickey)") {
+			return model.Repository{}, errors.New("failed with permission denied (publickey). Provide correct key in your ssh-agent")
+		}
+
+		return model.Repository{}, fmt.Errorf("failed to clone repository: %w", err)
+	}
+
+	g.fetch(ctx, destinationDir) //nolint
+
+	repo, err := git.PlainOpen(destinationDir)
+	if err != nil {
+		return model.Repository{}, fmt.Errorf("failed to open cloned repository: %w", err)
+	}
+
+	if !strings.EqualFold(option.Git.Type, gpsconfig.SSHAGENT) {
+		url = removeBasicAuthFromURL(url)
+
+		cfg, _ := repo.Config()
+		cfg.Remotes["origin"].URLs = []string{url}
+
+		err = repo.SetConfig(cfg)
+		if err != nil {
+			return model.Repository{}, fmt.Errorf("failed to set repository config: %w", err)
+		}
+	}
+
+	//panic(/* 333 */)
+
+	return model.NewRepository(repo) //nolint
+}
+
+func (g GitBinary) Pull(ctx context.Context, pullDirPath string, option model.PullOption) error {
+	logger := log.Logger(ctx)
+	option.DebugLog(logger).Msg("Git:Pull")
+
+	env := setupSSHCommandEnv(option.SSHClient.ProxyCommand, option.SSHClient.RewriteSSHURLFrom, option.SSHClient.RewriteSSHURLTo)
+
+	if err := g.runGitCommand(ctx, env, pullDirPath, "pull"); err != nil {
+		return fmt.Errorf("failed to pull repository: %w", err)
+	}
+
+	return g.fetch(ctx, pullDirPath)
+}
+
+func (g GitBinary) Push(ctx context.Context, _ interfaces.GitRepository, option model.PushOption, _ gpsconfig.ProviderConfig, _ gpsconfig.GitOption) error {
+	logger := log.Logger(ctx)
+	option.DebugLog(logger).Msg("GitBinary:Push")
+
+	env := setupSSHCommandEnv(option.SSHClient.ProxyCommand, option.SSHClient.RewriteSSHURLFrom, option.SSHClient.RewriteSSHURLTo)
+
+	args := append([]string{"push", option.Target}, option.RefSpecs...)
+
+	return g.runGitCommand(ctx, env, "", args...)
+}
+
+func (g GitBinary) fetch(ctx context.Context, workingDirPath string) error {
+	commands := [][]string{
+		{"fetch", "--all", "--prune"},
+		{"pull", "--all"},
+		{"pull", "--all"},
+	}
+
+	for _, cmd := range commands {
+		if err := g.runGitCommand(ctx, nil, workingDirPath, cmd...); err != nil {
+			return err
+		}
+	}
+
+	return g.createTrackingBranches(ctx, workingDirPath)
+}
+
+func (g GitBinary) runGitCommand(ctx context.Context, env []string, workingDir string, args ...string) error {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, g.gitBinaryPath, args...) //nolint:gosec
+
+	cmd.Env = append(os.Environ(), env...)
+	if len(workingDir) != 0 {
+		cmd.Dir = workingDir
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error executing '%s %s': %w. err: %s", g.gitBinaryPath, strings.Join(args, " "), err, output)
+	}
+
+	log.Logger(ctx).Debug().Msgf("Git command output:%s", output)
+
+	return nil
+}
+
+func addBasicAuthToURL(urlStr, username, password string) string {
+	// Parse the URL
+	parsedURL, _ := url.Parse(urlStr)
+
+	// Add the username and password to the URL
+	parsedURL.User = url.UserPassword(username, password)
+
+	// Return the modified URL as a string
+	return parsedURL.String()
+}
+
+func removeBasicAuthFromURL(urlStr string) string {
+	// Parse the URL
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		// If there's an error parsing the URL, return the original string
+		return urlStr
+	}
+
+	// Remove the username and password from the URL
+	parsedURL.User = nil
+
+	// Return the modified URL as a string
+	return parsedURL.String()
+}
+
+func (g GitBinary) createTrackingBranches(ctx context.Context, repoPath string) error {
+	output, err := g.runGitCommandWithOutput(ctx, repoPath, "branch", "-r")
+	if err != nil {
+		return fmt.Errorf("error getting remote branches: %w", err)
+	}
+
+	for _, branch := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		branch = strings.TrimSpace(branch)
+		if strings.Contains(branch, "->") {
+			continue // Skip HEAD reference
+		}
+
+		localBranch := strings.TrimPrefix(branch, "origin/")
+		if err := g.runGitCommand(ctx, nil, repoPath, "branch", "--track", localBranch, branch); err != nil {
+			if !strings.Contains(err.Error(), "already exists") {
+				log.Logger(ctx).Debug().Msgf("Could not create tracking branch for %s: %v", branch, err)
+			}
+		} else {
+			log.Logger(ctx).Debug().Msgf("Created tracking branch for %s", branch)
+		}
+	}
+
+	return nil
+}
+
+func (g GitBinary) runGitCommandWithOutput(ctx context.Context, workingDir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, g.gitBinaryPath, args...) //nolint:gosec
+	cmd.Dir = workingDir
+
+	return cmd.Output() //nolint
+}
+
+func ValidateGitBinary() (string, error) {
+	paths := []string{"git", "/usr/bin/git", "/usr/local/bin/git", "/opt/homebrew/bin/git"}
+	for _, path := range paths {
+		if output, err := exec.Command(path, "--version").Output(); err == nil && strings.HasPrefix(string(output), "git version") {
+			return path, nil
+		}
+	}
+
+	return "", errors.New("no valid git executable found")
+}
+
+func setupSSHCommandEnv(proxycommand, rewriteurlfrom, rewriteurlto string) []string {
+	if proxycommand == "" {
+		return []string{}
+	}
+
+	return []string{
+		"GIT_SSH_COMMAND=" + proxycommand,
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=url." + rewriteurlto + ".insteadOf",
+		"GIT_CONFIG_VALUE_0=" + rewriteurlfrom,
+	}
+}


### PR DESCRIPTION
Adds support for using a host git binary instead of the go-go library.
Adds support custom ssh-additions

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).

