### PR TITLE
fix(gitlab): use ns-id for groups

### DIFF
--- a/internal/provider/github/client.go
+++ b/internal/provider/github/client.go
@@ -93,9 +93,9 @@ func (ghc Client) Metainfos(ctx context.Context, config config.ProviderConfig, f
 
 	var err error
 
-	listType := "all"
+	listType := "sources"
 	if config.Git.IncludeForks {
-		listType = "public,private,forks"
+		listType = "all"
 	}
 
 	if config.IsGroup() {


### PR DESCRIPTION
Use the namespaceid for GitLab group create. This avoids potential confusion regarding under which group the project should be created.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).

