### PR TITLE
fix(github): replace branch and tag protections with ruleset

### DIFF
--- a/internal/provider/github/options.go
+++ b/internal/provider/github/options.go
@@ -27,23 +27,25 @@ func (p *ProjectOptionsBuilder) basicOpts(visibility, name, description, default
 		isPrivate = true
 	}
 
-	p.opts.Name = &name
+	p.opts.AllowAutoMerge = github.Bool(true)
 	p.opts.AllowForking = github.Bool(true)
-	p.opts.Private = &isPrivate
+	p.opts.AllowRebaseMerge = github.Bool(true)
+	p.opts.AllowSquashMerge = github.Bool(true)
 	p.opts.DefaultBranch = &defaultBranch
 	p.opts.Description = &description
+	p.opts.Name = &name
+	p.opts.Private = &isPrivate
 }
 
 func (p *ProjectOptionsBuilder) disableFeatures() {
+	p.opts.AllowAutoMerge = github.Bool(false)
+	p.opts.AllowMergeCommit = github.Bool(false)
+	p.opts.AllowSquashMerge = github.Bool(false)
+	p.opts.AllowUpdateBranch = github.Bool(false)
+	p.opts.DeleteBranchOnMerge = github.Bool(false)
+	p.opts.HasDownloads = github.Bool(false)
 	p.opts.HasIssues = github.Bool(false)
-	p.opts.HasWiki = github.Bool(false)
 	p.opts.HasPages = github.Bool(false)
 	p.opts.HasProjects = github.Bool(false)
-	p.opts.HasDownloads = github.Bool(false)
-	p.opts.AllowSquashMerge = github.Bool(false)
-	p.opts.AllowMergeCommit = github.Bool(false)
-	p.opts.AllowRebaseMerge = github.Bool(false)
-	p.opts.DeleteBranchOnMerge = github.Bool(false)
-	p.opts.AllowAutoMerge = github.Bool(false)
-	p.opts.AllowUpdateBranch = github.Bool(false)
+	p.opts.HasWiki = github.Bool(false)
 }


### PR DESCRIPTION
Modern GitHub uses rulesets instead of branch and tag protection

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).

